### PR TITLE
kotlin synthetics 대신 jetpack view binding 활용하도록 수정 (WIP)

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
+apply plugin: 'kotlin-kapt'
+
 android {
     compileSdkVersion 29
 
@@ -127,6 +129,16 @@ dependencies {
     api 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
     api 'com.squareup.okhttp3:okhttp:3.11.0'
     api 'com.squareup.okhttp3:logging-interceptor:3.11.0'
+
+    //Kotlin Coroutines
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1'
+
+    //Jetpack
+    api 'androidx.lifecycle:lifecycle-runtime:2.2.0-alpha01'
+    api 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-alpha01'
+    kapt 'androidx.lifecycle:lifecycle-compiler:2.2.0-alpha01'
+
     testImplementation 'junit:junit:4.12'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -5,6 +5,10 @@ apply plugin: 'maven-publish'
 android {
     compileSdkVersion 29
 
+    buildFeatures {
+        viewBinding true
+    }
+
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 29
@@ -127,6 +131,8 @@ dependencies {
     api 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
     api 'com.squareup.okhttp3:okhttp:3.11.0'
     api 'com.squareup.okhttp3:logging-interceptor:3.11.0'
+    api 'com.github.chrisbanes:PhotoView:2.0.0'
+    implementation 'androidx.databinding:viewbinding:7.0.4'
     testImplementation 'junit:junit:4.12'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/common/src/main/java/com/swc/common/ui/activity/BaseActivity.kt
+++ b/common/src/main/java/com/swc/common/ui/activity/BaseActivity.kt
@@ -4,9 +4,11 @@ import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.widget.Toolbar
+import androidx.viewbinding.ViewBinding
 import com.swc.common.BuildConfig
 import com.swc.common.R
 import com.swc.common.ui.custom.SToolbar
@@ -23,7 +25,13 @@ import java.util.concurrent.TimeUnit
 Created by sangwn.choi on2020-06-29
 
  **/
-abstract class BaseActivity: RxAppCompatActivity() {
+abstract class BaseActivity<VB: ViewBinding>: RxAppCompatActivity() {
+    private var _binding: ViewBinding? = null
+    abstract val bindingInflater: (LayoutInflater) -> VB
+
+    protected val binding: VB
+        get() = _binding as VB
+
     private var mInteractionSubject: PublishSubject<Int>? = null
     abstract val mLayoutId: Int
     private val className: String = this.javaClass.simpleName
@@ -87,6 +95,9 @@ abstract class BaseActivity: RxAppCompatActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 
         setStatusBarColor()
+
+        //set view binding
+        _binding = bindingInflater.invoke(layoutInflater)
 
         //set content view here
         setContentView(mLayoutId)

--- a/common/src/main/java/com/swc/common/ui/activity/BaseActivity.kt
+++ b/common/src/main/java/com/swc/common/ui/activity/BaseActivity.kt
@@ -19,6 +19,7 @@ import com.trello.rxlifecycle4.components.support.RxAppCompatActivity
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import io.reactivex.rxjava3.subjects.PublishSubject
+import kotlinx.android.synthetic.main.drawer_toolbar.view.*
 import java.util.concurrent.TimeUnit
 
 /**
@@ -29,26 +30,30 @@ abstract class BaseActivity<VB: ViewBinding>: RxAppCompatActivity() {
     private var _binding: ViewBinding? = null
     abstract val bindingInflater: (LayoutInflater) -> VB
 
-    protected val binding: VB
+    public val binding: VB
         get() = _binding as VB
 
     private var mInteractionSubject: PublishSubject<Int>? = null
-    abstract val mLayoutId: Int
+//    abstract val mLayoutId: Int
     private val className: String = this.javaClass.simpleName
 
     abstract fun setLayout()
 
     open fun setToolbar() {
-
-        findViewById<Toolbar>(R.id.toolbar_id)?.let {
-            it.removeAllViews()
-            it.addView(layoutInflater.inflate(R.layout.drawer_toolbar, null))
-        }
+// viewbinding 적용 시, 여기서 새로 툴바 뷰 추가해줄 필요 없음..
+//        findViewById<SToolbar>(R.id.toolbar_id)?.let {
+//            LOG.e("set toolbar")
+//            it.removeAllViews()
+//            it.addView(layoutInflater.inflate(R.layout.drawer_toolbar, null))
+//        }
     }
 
-    fun getToolbar(): SToolbar? {
-        return findViewById<SToolbar>(R.id.toolbar_id)
-    }
+
+//    fun getToolbar(): SToolbar? {
+//        LOG.e("get toolbar is null? ${findViewById<SToolbar>(R.id.toolbar_id) == null}")
+//        return findViewById<SToolbar>(R.id.toolbar_id)
+//    }
+    abstract fun getToolbar() : SToolbar?
 
     override fun onStart() {
         super.onStart()
@@ -62,6 +67,7 @@ abstract class BaseActivity<VB: ViewBinding>: RxAppCompatActivity() {
 
     override fun onDestroy() {
         LOG.e(className, "onDestroy")
+        _binding = null
         super.onDestroy()
     }
 
@@ -100,7 +106,7 @@ abstract class BaseActivity<VB: ViewBinding>: RxAppCompatActivity() {
         _binding = bindingInflater.invoke(layoutInflater)
 
         //set content view here
-        setContentView(mLayoutId)
+        setContentView(binding.root)
 
         //set toolbar here
         setToolbar()

--- a/common/src/main/java/com/swc/common/ui/activity/BaseSplashActivity.kt
+++ b/common/src/main/java/com/swc/common/ui/activity/BaseSplashActivity.kt
@@ -1,16 +1,12 @@
 package com.swc.common.ui.activity
 
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.os.IBinder
 import android.os.RemoteException
 import android.util.Log
 import android.widget.Toast
+import androidx.viewbinding.ViewBinding
 import com.swc.common.BuildConfig
 import com.swc.common.R
 import com.swc.common.ui.fragment.PopupDialogFragment
@@ -30,7 +26,7 @@ import java.util.concurrent.TimeUnit
 Created by sangwn.choi on2020-07-03
 
  **/
-abstract class BaseSplashActivity : BaseActivity() {
+abstract class BaseSplashActivity<VB: ViewBinding> : BaseActivity<VB>() {
     abstract val myClass: Class<*>?
     private var mIsBound = false
 
@@ -40,13 +36,13 @@ abstract class BaseSplashActivity : BaseActivity() {
         Single.just(0).delay(1000, TimeUnit.MILLISECONDS)
             .compose(bindUntilEvent(ActivityEvent.DESTROY))
             .subscribe({
-                checkPrerequisites()
+                checkPrerequisites<VB>()
             }, {
 
             })
     }
 
-    private fun checkPrerequisites() {
+    private fun <VB> checkPrerequisites() {
         PrerequisiteCheckState.NetworkCheckState.proceed(this@BaseSplashActivity)
     }
 
@@ -55,7 +51,7 @@ abstract class BaseSplashActivity : BaseActivity() {
         object SecurityCheckState : PrerequisiteCheckState()
         object FinalCheckState : PrerequisiteCheckState()
 
-        fun proceed(activity: BaseSplashActivity) {
+        fun <VB : ViewBinding> proceed(activity: BaseSplashActivity<VB>) {
             LOG.e("proceed ${this.javaClass.simpleName}")
             when (this) {
                 is NetworkCheckState -> {

--- a/common/src/main/java/com/swc/common/ui/adapter/BaseAdapter.kt
+++ b/common/src/main/java/com/swc/common/ui/adapter/BaseAdapter.kt
@@ -3,6 +3,7 @@ package com.swc.common.ui.adapter
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
+import androidx.viewbinding.ViewBinding
 import kotlinx.android.extensions.LayoutContainer
 
 /**
@@ -111,6 +112,7 @@ abstract class BaseAdapter<T>(
  */
 abstract class BaseViewHolder(override val containerView: View) :
     RecyclerView.ViewHolder(containerView), LayoutContainer {
+    abstract val binding: ViewBinding
     //perform binding.
     abstract fun bindVH(position: Int)
 }

--- a/common/src/main/java/com/swc/common/ui/custom/SToolbar.kt
+++ b/common/src/main/java/com/swc/common/ui/custom/SToolbar.kt
@@ -4,9 +4,14 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.viewbinding.ViewBinding
 import com.swc.common.R
-import kotlinx.android.synthetic.main.drawer_toolbar.view.*
+import com.swc.common.databinding.DrawerToolbarBinding
+import com.swc.common.util.LOG
+
+//import kotlinx.android.synthetic.main.drawer_toolbar.view.*
 
 
 /**
@@ -16,24 +21,31 @@ Created by sangwn.choi on2020-07-09
 class SToolbar @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : Toolbar(context, attrs, defStyleAttr) {
+    val binding: DrawerToolbarBinding = DrawerToolbarBinding.inflate(LayoutInflater.from(context), this, false)
 
     init {
         id = R.id.toolbar_id
         removeAllViews()
-        addView(LayoutInflater.from(context).inflate(R.layout.drawer_toolbar, null))
+//        binding =
+        addView(binding.root)
+//        addView(LayoutInflater.from(context).inflate(R.layout.drawer_toolbar, null))
     }
 
     fun setSToolbarTitle(charSequence: CharSequence) {
-        tvToolbarTitle?.text = charSequence
+        LOG.e("SToolbar setSToolbarTitle from: ${binding.tvToolbarTitle.text} , to: $charSequence")
+
+        binding.tvToolbarTitle.text = charSequence
     }
 
     fun setSToolbarImage(resId: Int) {
-        ivMenu?.setImageResource(resId)
+        binding.ivMenu.setImageResource(resId)
     }
 
     fun setToolbarAction(action: (() -> Unit)?) {
-        ivMenu?.setOnClickListener {
+        binding.ivMenu.setOnClickListener {
             action?.invoke()
         }
     }
+
+
 }

--- a/common/src/main/java/com/swc/common/ui/fragment/BaseDialogFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/BaseDialogFragment.kt
@@ -5,14 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import androidx.viewbinding.ViewBinding
 
 
 /**
 Created by sangwn.choi on2020-06-29
 
  **/
-abstract class BaseDialogFragment: DialogFragment() {
-    abstract val layoutId: Int
+abstract class BaseDialogFragment<VB: ViewBinding>: DialogFragment() {
+    protected var _binding: ViewBinding? = null
+    abstract val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> VB
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    protected val binding: VB
+        get() = _binding as VB
+
+//    abstract val layoutId: Int
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,8 +30,15 @@ abstract class BaseDialogFragment: DialogFragment() {
         return super.onCreateView(inflater, container, savedInstanceState)?.run {
             this
         }?: run {
-            inflater.inflate(layoutId, container, false)
+            _binding = bindingInflater.invoke(inflater, container, false)
+            (_binding as VB).root
+//            inflater.inflate(layoutId, container, false)
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/common/src/main/java/com/swc/common/ui/fragment/BaseFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/BaseFragment.kt
@@ -28,7 +28,7 @@ abstract class BaseFragment<VB: ViewBinding> : RxFragment(), View.OnClickListene
     protected val binding: VB
         get() = _binding as VB
 
-    abstract val layoutId: Int
+//    abstract val layoutId: Int
     private val className: String = this.javaClass.simpleName
 
     open var loadingView: LoadingView? = null
@@ -36,7 +36,7 @@ abstract class BaseFragment<VB: ViewBinding> : RxFragment(), View.OnClickListene
     var hasInitializedRootView = false
     private var rootView: View? = null
 
-    private fun getPersistentView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?, layout: Int): View? {
+    private fun getPersistentView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         if (rootView == null) {
             // Inflate the layout for this fragment
             _binding = bindingInflater.invoke(inflater, container, false)
@@ -53,7 +53,7 @@ abstract class BaseFragment<VB: ViewBinding> : RxFragment(), View.OnClickListene
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return getPersistentView(inflater, container, savedInstanceState, layoutId)
+        return getPersistentView(inflater, container, savedInstanceState)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -122,6 +122,7 @@ abstract class BaseFragment<VB: ViewBinding> : RxFragment(), View.OnClickListene
 
     override fun onDestroyView() {
         LOG.e(className, "onDestroyView")
+        _binding = null
         super.onDestroyView()
     }
 }

--- a/common/src/main/java/com/swc/common/ui/fragment/BaseWebviewFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/BaseWebviewFragment.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.webkit.*
+import androidx.viewbinding.ViewBinding
 import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewFeature
@@ -18,7 +19,7 @@ import kotlinx.android.synthetic.main.fragment_webview_base.*
 Created by sangwn.choi on2020-07-01
 
  **/
-abstract class BaseWebviewFragment : BaseFragment() {
+abstract class BaseWebviewFragment<VB: ViewBinding> : BaseFragment<VB>() {
     open var initialUrl: String? = null
 
     override val layoutId: Int
@@ -58,7 +59,7 @@ abstract class BaseWebviewFragment : BaseFragment() {
 
     }
 
-    class CustomChromeClient(private val baseWebviewFragment: BaseWebviewFragment? = null) : WebChromeClient() {
+    class CustomChromeClient<VB: ViewBinding>(private val baseWebviewFragment: BaseWebviewFragment<VB>? = null) : WebChromeClient() {
 
         override fun onJsAlert(view: WebView?, url: String?, message: String?, result: JsResult?): Boolean {
 //
@@ -77,7 +78,7 @@ abstract class BaseWebviewFragment : BaseFragment() {
         }
     }
 
-    class CustomWebViewClient(private val baseWebviewFragment: BaseWebviewFragment? = null) : WebViewClientCompat() {
+    class CustomWebViewClient<VB: ViewBinding>(private val baseWebviewFragment: BaseWebviewFragment<VB>? = null) : WebViewClientCompat() {
         //TODO: onPageFinished,onPageStarted,shouldOverrideUrlLoading override
 
         override fun onPageFinished(view: WebView?, url: String?) {

--- a/common/src/main/java/com/swc/common/ui/fragment/BaseWebviewFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/BaseWebviewFragment.kt
@@ -3,27 +3,36 @@ package com.swc.common.ui.fragment
 import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.*
 import androidx.viewbinding.ViewBinding
 import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewFeature
 import com.swc.common.R
+import com.swc.common.databinding.DrawerToolbarBinding
+import com.swc.common.databinding.FragmentWebviewBaseBinding
 import com.swc.common.util.LOG
 import com.swc.common.util.PopupDialogUtil
-import kotlinx.android.synthetic.main.fragment_webview_base.*
+//import kotlinx.android.synthetic.main.fragment_webview_base.*
 
 
 /**
 Created by sangwn.choi on2020-07-01
 
  **/
-abstract class BaseWebviewFragment<VB: ViewBinding> : BaseFragment<VB>() {
+abstract class BaseWebviewFragment : BaseFragment<FragmentWebviewBaseBinding>() {
+
+    override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentWebviewBaseBinding = {
+            inflater, container, attachToParent -> FragmentWebviewBaseBinding.inflate(inflater, container, attachToParent)
+    }
+
     open var initialUrl: String? = null
 
-    override val layoutId: Int
-        get() = R.layout.fragment_webview_base
+//    override val layoutId: Int
+//        get() = R.layout.fragment_webview_base
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,9 +46,9 @@ abstract class BaseWebviewFragment<VB: ViewBinding> : BaseFragment<VB>() {
 
     override fun setLayout() {
         //init webview
-        loadingView = lvWeb
+        loadingView = binding.lvWeb
 
-        wvBase?.run {
+        binding.wvBase?.run {
             webViewClient =
                 CustomWebViewClient(this@BaseWebviewFragment)
             webChromeClient =
@@ -59,7 +68,7 @@ abstract class BaseWebviewFragment<VB: ViewBinding> : BaseFragment<VB>() {
 
     }
 
-    class CustomChromeClient<VB: ViewBinding>(private val baseWebviewFragment: BaseWebviewFragment<VB>? = null) : WebChromeClient() {
+    class CustomChromeClient(private val baseWebviewFragment: BaseWebviewFragment? = null) : WebChromeClient() {
 
         override fun onJsAlert(view: WebView?, url: String?, message: String?, result: JsResult?): Boolean {
 //
@@ -78,7 +87,7 @@ abstract class BaseWebviewFragment<VB: ViewBinding> : BaseFragment<VB>() {
         }
     }
 
-    class CustomWebViewClient<VB: ViewBinding>(private val baseWebviewFragment: BaseWebviewFragment<VB>? = null) : WebViewClientCompat() {
+    class CustomWebViewClient(private val baseWebviewFragment: BaseWebviewFragment? = null) : WebViewClientCompat() {
         //TODO: onPageFinished,onPageStarted,shouldOverrideUrlLoading override
 
         override fun onPageFinished(view: WebView?, url: String?) {

--- a/common/src/main/java/com/swc/common/ui/fragment/PopupDialogFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/PopupDialogFragment.kt
@@ -3,18 +3,27 @@ package com.swc.common.ui.fragment
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import com.swc.common.R
-import kotlinx.android.synthetic.main.fragment_popup_dialog.*
+import com.swc.common.databinding.FragmentPopupDialogBinding
+import com.swc.common.databinding.FragmentScrollingPopupDialogBinding
+
+//import kotlinx.android.synthetic.main.fragment_popup_dialog.*
 
 
 /**
 Created by sangwn.choi on2020-06-29
 
  **/
-open class PopupDialogFragment : BaseDialogFragment() {
-    override val layoutId: Int =
-        R.layout.fragment_popup_dialog
+open class PopupDialogFragment : BaseDialogFragment<FragmentPopupDialogBinding>() {
+//    override val layoutId: Int =
+//        R.layout.fragment_popup_dialog
+
+    override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentPopupDialogBinding = {
+            inflater, container, attachToParent -> FragmentPopupDialogBinding.inflate(inflater, container, attachToParent)
+    }
 
     private var mTitle: CharSequence? = null
     internal var mImage: Any? = null
@@ -79,10 +88,10 @@ open class PopupDialogFragment : BaseDialogFragment() {
 
     private fun setTitle(title: CharSequence?) {
         title?.run {
-            tvPopupTitle?.text = this
+            binding.tvPopupTitle.text = this
         } ?: run {
-            tvPopupTitle?.visibility = View.GONE
-            vBorder?.visibility = View.GONE
+            binding.tvPopupTitle.visibility = View.GONE
+            binding.vBorder.visibility = View.GONE
         }
     }
 
@@ -92,17 +101,17 @@ open class PopupDialogFragment : BaseDialogFragment() {
                 is String -> {
                     //url? or could be local path..
                     //필요할 경우 Glide 추가
-                    ivPopupIcon?.setImageURI(Uri.parse(this))
+                    binding.ivPopupIcon.setImageURI(Uri.parse(this))
                 }
 
                 is Int -> {
                     //res id
-                    ivPopupIcon?.setImageResource(this)
+                    binding.ivPopupIcon.setImageResource(this)
                 }
 
                 is Drawable -> {
                     //drawable
-                    ivPopupIcon?.setImageDrawable(this)
+                    binding.ivPopupIcon.setImageDrawable(this)
                 }
 
                 else -> {
@@ -110,46 +119,46 @@ open class PopupDialogFragment : BaseDialogFragment() {
                 }
             }
         }?: run {
-            ivPopupIcon?.visibility = View.GONE
+            binding.ivPopupIcon.visibility = View.GONE
         }
 
     }
 
     private fun setContent(content: CharSequence?) {
         content?.run {
-            tvPopupContent?.text = this
+            binding.tvPopupContent.text = this
         } ?: run {
-            tvPopupContent?.visibility = View.GONE
+            binding.tvPopupContent.visibility = View.GONE
         }
     }
 
     private fun setDesc(desc: CharSequence?) {
         desc?.run {
-            tvPopupDesc?.text = this
+            binding.tvPopupDesc.text = this
         } ?: run {
-            tvPopupDesc?.visibility = View.GONE
+            binding.tvPopupDesc.visibility = View.GONE
         }
     }
 
     private fun setOkText(okText: CharSequence?) {
         okText?.run {
-            btnOk?.text = this
+            binding.btnOk.text = this
         } ?: run {
-            btnOk?.visibility = View.GONE
+            binding.btnOk.visibility = View.GONE
         }
     }
 
     private fun setCancelText(cancelText: CharSequence?) {
         cancelText?.run {
-            btnCancel?.text = this
+            binding.btnCancel.text = this
         } ?: run {
-            btnCancel?.visibility = View.GONE
+            binding.btnCancel.visibility = View.GONE
         }
     }
 
     private fun setOkAction(action: (() -> Unit)?) {
         action?.run {
-            btnOk?.setOnClickListener {
+            binding.btnOk.setOnClickListener {
                 this.invoke()
                 dismiss()
             }
@@ -158,7 +167,7 @@ open class PopupDialogFragment : BaseDialogFragment() {
 
     private fun setCancelAction(action: (() -> Unit)?) {
         action?.run {
-            btnCancel?.setOnClickListener {
+            binding.btnCancel.setOnClickListener {
                 this.invoke()
                 dismiss()
             }

--- a/common/src/main/java/com/swc/common/ui/fragment/ScrollingPopupDialogFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/ScrollingPopupDialogFragment.kt
@@ -1,10 +1,14 @@
 package com.swc.common.ui.fragment
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import com.swc.common.util.LOG
 import com.swc.common.R
-import kotlinx.android.synthetic.main.fragment_scrolling_popup_dialog.*
+import com.swc.common.databinding.FragmentScrollingPopupDialogBinding
+
+//import kotlinx.android.synthetic.main.fragment_scrolling_popup_dialog.*
 
 
 /**
@@ -12,7 +16,27 @@ Created by sangwn.choi on2020-08-03
 
  **/
 class ScrollingPopupDialogFragment: PopupDialogFragment() {
-    override val layoutId: Int = R.layout.fragment_scrolling_popup_dialog
+//    override val layoutId: Int = R.layout.fragment_scrolling_popup_dialog
+
+    val sBindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentScrollingPopupDialogBinding = {
+            inflater, container, attachToParent -> FragmentScrollingPopupDialogBinding.inflate(inflater, container, attachToParent)
+    }
+    protected val sBinding: FragmentScrollingPopupDialogBinding
+        get() = _binding as FragmentScrollingPopupDialogBinding
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return super.onCreateView(inflater, container, savedInstanceState)?.run {
+            this
+        }?: run {
+            _binding = sBindingInflater.invoke(inflater, container, false)
+            (_binding as FragmentScrollingPopupDialogBinding).root
+        }
+    }
 
     class ScrollingPopupDialogBuilder: PopupDialogBuilder() {
 
@@ -38,7 +62,7 @@ class ScrollingPopupDialogFragment: PopupDialogFragment() {
         super.setImage(image)
 
         image?.run {
-            svPopupDesc?.visibility = View.GONE
+            sBinding.svPopupDesc?.visibility = View.GONE
         }
     }
 

--- a/common/src/main/java/com/swc/common/ui/fragment/ZoomImagePopupDialogFragment.kt
+++ b/common/src/main/java/com/swc/common/ui/fragment/ZoomImagePopupDialogFragment.kt
@@ -1,10 +1,15 @@
 package com.swc.common.ui.fragment
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import com.swc.common.util.LOG
 import com.swc.common.R
-import kotlinx.android.synthetic.main.fragment_scrolling_popup_dialog.*
+import com.swc.common.databinding.FragmentScrollingPopupDialogBinding
+import com.swc.common.databinding.FragmentZoomingPopupDialogBinding
+
+//import kotlinx.android.synthetic.main.fragment_scrolling_popup_dialog.*
 
 
 /**
@@ -12,7 +17,27 @@ Created by sangwn.choi on2020-08-03
 
  **/
 class ZoomImagePopupDialogFragment: PopupDialogFragment() {
-    override val layoutId: Int = R.layout.fragment_zooming_popup_dialog
+//    override val layoutId: Int = R.layout.fragment_zooming_popup_dialog
+
+    val zBindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentZoomingPopupDialogBinding = {
+            inflater, container, attachToParent -> FragmentZoomingPopupDialogBinding.inflate(inflater, container, attachToParent)
+    }
+    protected val zBinding: FragmentZoomingPopupDialogBinding
+        get() = _binding as FragmentZoomingPopupDialogBinding
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return super.onCreateView(inflater, container, savedInstanceState)?.run {
+            this
+        }?: run {
+            _binding = zBindingInflater.invoke(inflater, container, false)
+            (_binding as FragmentScrollingPopupDialogBinding).root
+        }
+    }
 
     class ZoomImagePopupDialogBuilder: PopupDialogBuilder() {
 
@@ -38,7 +63,7 @@ class ZoomImagePopupDialogFragment: PopupDialogFragment() {
         super.setImage(image)
 
         image?.run {
-            svPopupDesc?.visibility = View.GONE
+            zBinding.svPopupDesc.visibility = View.GONE
         }
     }
 

--- a/common/src/main/res/layout/drawer_toolbar.xml
+++ b/common/src/main/res/layout/drawer_toolbar.xml
@@ -29,6 +29,7 @@
         app:layout_constraintLeft_toRightOf="@id/ivMenu"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
+        android:text = "ABC"
         tools:text="감염병 정보"/>
 
 

--- a/sampleapp/build.gradle
+++ b/sampleapp/build.gradle
@@ -7,6 +7,10 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 android {
     compileSdkVersion 29
 
+    buildFeatures {
+        viewBinding true
+    }
+
 //    - 앱 이름 : 별도 규칙 없음
 //    - Package 코드 : 앱 이름에 맞게 진행
 //    - Version Code : 년도 2자리 + 월 2자리 + 일 2자리 + 일련번호 2자리(예:18123101, 18123102)

--- a/sampleapp/src/main/java/com/swc/sampleapp/UserApiClient.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/UserApiClient.kt
@@ -21,8 +21,11 @@ Created by sangwn.choi on2020-07-13
 interface UserApiClient {
 
 
+//    @GET("ck")
+//    fun getCk(): Flowable<BResponse<SampleResp>>
+
     @GET("ck")
-    fun getCk(): Flowable<BResponse<SampleResp>>
+    suspend fun getCk(): BResponse<SampleResp>
 
     companion object {
         private var retrofit: Retrofit? = null
@@ -34,7 +37,7 @@ interface UserApiClient {
                     .addConverterFactory(GsonConverterFactory.create())
                     .baseUrl(BASE_URL)
                     .client(ApiClient.client)
-                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+//                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                     .build()
             }
             return retrofit!!.create(UserApiClient::class.java)

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/MainActivity.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.swc.common.ui.activity.BaseActivity
+import com.swc.common.ui.custom.SToolbar
 import com.swc.common.ui.fragment.PopupDialogFragment
 import com.swc.common.util.LOG
 import com.swc.common.util.PopupDialogUtil
@@ -20,8 +21,10 @@ import com.swc.sampleapp.databinding.ActivitySplashBinding
 import com.swc.sampleapp.extension.navigateSafely
 import com.swc.sampleapp.ui.adapter.DrawerEntryAdapter
 import com.swc.sampleapp.ui.adapter.DrawerItem
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.nav_footer.*
+import kotlinx.android.synthetic.main.activity_main.view.*
+
+//import kotlinx.android.synthetic.main.activity_main.*
+//import kotlinx.android.synthetic.main.nav_footer.*
 
 
 /**
@@ -29,13 +32,15 @@ Created by sangwn.choi on2020-06-29
 
  **/
 class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
-    override val mLayoutId = R.layout.activity_main
+//    override val mLayoutId = R.layout.activity_main
 
     override fun setToolbar() {
         super.setToolbar()
 
+        binding.toolbarId.setSToolbarTitle("DEF")
+
         findViewById<ImageView>(R.id.ivMenu)?.setOnClickListener {
-            dlMenu?.openDrawer(GravityCompat.START)
+            binding.dlMenu.openDrawer(GravityCompat.START)
         }
     }
 
@@ -46,7 +51,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
     override fun setLayout() {
 
         //drawer init
-        rvNavMenu?.initialize(DrawerEntryAdapter(clickListener = this@MainActivity).apply {
+        binding.rvNavMenu.initialize(DrawerEntryAdapter(clickListener = this@MainActivity).apply {
             add(DrawerItem(getString(R.string.menu_home), R.drawable.ic_home_orange))
             add(DrawerItem(getString(R.string.menu_f), R.drawable.ic_announcement_orange))
             add(DrawerItem(getString(R.string.menu_e), R.drawable.ic_pandemic_info))
@@ -56,11 +61,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
             add(DrawerItem(getString(R.string.menu_a), R.drawable.ic_faq))
         })
 
-        tvOpenSource?.setOnClickListener(this)
-        tvPrivacyPolicy?.setOnClickListener(this)
+        binding.navFooter.tvOpenSource.setOnClickListener(this)
+        binding.navFooter.tvOpenSource.setOnClickListener(this)
+        binding.navFooter.tvPrivacyPolicy.setOnClickListener(this)
 
-        tvAppVersion?.text = getString(R.string.app_version, BuildConfig.VERSION_NAME)
-        tvAppVersion?.setOnClickListener(this)
+        binding.navFooter.tvAppVersion.text = getString(R.string.app_version, BuildConfig.VERSION_NAME)
+        binding.navFooter.tvAppVersion.setOnClickListener(this)
 
         //nav graph start
         findNavController(R.id.navHostFragment).run {
@@ -72,8 +78,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
     override fun onBackPressed() {
         LOG.e("Main onBackPressed")
 
-        if (dlMenu?.isDrawerOpen(GravityCompat.START) == true) {
-            dlMenu?.closeDrawer(GravityCompat.START)
+        if (binding.dlMenu.isDrawerOpen(GravityCompat.START)) {
+            binding.dlMenu.closeDrawer(GravityCompat.START)
         } else {
 
             findNavController(R.id.navHostFragment).run {
@@ -91,7 +97,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
                         .show(supportFragmentManager, null)
                 } else {
                     //이전 화면이동시 hide loading
-                    lvMain?.visibility = View.GONE
+                    binding.lvMain.visibility = View.GONE
                     super.onBackPressed()
                 }
             }
@@ -101,7 +107,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
     }
 
     private fun getForegroundFragmentArgs(): Bundle? {
-        return (navHostFragment.childFragmentManager.fragments[0] ?: navHostFragment).arguments
+        val frag = supportFragmentManager.findFragmentById(R.id.navHostFragment)
+
+        frag?.run {
+            return (childFragmentManager.fragments[0] ?: this).arguments
+        }
+        return null
     }
 
     override fun onClick(v: View?) {
@@ -112,13 +123,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
                     LOG.e("swc", "clDrawer click")
 
                     //close drawer
-                    if (dlMenu?.isDrawerOpen(GravityCompat.START) == true) {
-                        dlMenu?.closeDrawer(GravityCompat.START)
+                    if (binding.dlMenu.isDrawerOpen(GravityCompat.START)) {
+                        binding.dlMenu.closeDrawer(GravityCompat.START)
                     }
 
                     //move to nav page..WIP
 
-                    rvNavMenu?.run {
+                    binding.rvNavMenu.run {
                         val pos = getChildAdapterPosition(v)
                         (adapter?.getItem(pos) as? DrawerItem)?.run {
                             LOG.e("item title $title")
@@ -126,7 +137,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
 
                             when (title) {
                                 getString(R.string.menu_home) -> {
-                                    navHostFragment.findNavController().navigateSafely(
+                                    supportFragmentManager.findFragmentById(R.id.navHostFragment)?.findNavController()?.navigateSafely(
                                         R.id.action_home,
                                         getForegroundFragmentArgs()
                                     )
@@ -170,6 +181,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
                 }
             }
         }
+    }
+
+    override fun getToolbar(): SToolbar? {
+        return binding.toolbarId
     }
 
 

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/MainActivity.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/MainActivity.kt
@@ -2,6 +2,7 @@ package com.swc.sampleapp.ui.activity
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import androidx.core.view.GravityCompat
@@ -14,6 +15,8 @@ import com.swc.common.util.LOG
 import com.swc.common.util.PopupDialogUtil
 import com.swc.sampleapp.BuildConfig
 import com.swc.sampleapp.R
+import com.swc.sampleapp.databinding.ActivityMainBinding
+import com.swc.sampleapp.databinding.ActivitySplashBinding
 import com.swc.sampleapp.extension.navigateSafely
 import com.swc.sampleapp.ui.adapter.DrawerEntryAdapter
 import com.swc.sampleapp.ui.adapter.DrawerItem
@@ -25,7 +28,7 @@ import kotlinx.android.synthetic.main.nav_footer.*
 Created by sangwn.choi on2020-06-29
 
  **/
-class MainActivity : BaseActivity(), View.OnClickListener {
+class MainActivity : BaseActivity<ActivityMainBinding>(), View.OnClickListener {
     override val mLayoutId = R.layout.activity_main
 
     override fun setToolbar() {
@@ -34,6 +37,10 @@ class MainActivity : BaseActivity(), View.OnClickListener {
         findViewById<ImageView>(R.id.ivMenu)?.setOnClickListener {
             dlMenu?.openDrawer(GravityCompat.START)
         }
+    }
+
+    override val bindingInflater: (LayoutInflater) -> ActivityMainBinding = {
+            inflater -> ActivityMainBinding.inflate(inflater)
     }
 
     override fun setLayout() {

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/SplashActivity.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/SplashActivity.kt
@@ -1,21 +1,29 @@
 package com.swc.sampleapp.ui.activity
 
 import android.content.Intent
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import com.swc.common.ui.activity.BaseSplashActivity
 import com.swc.common.util.LOG
 import com.swc.sampleapp.R
+import com.swc.sampleapp.databinding.ActivitySplashBinding
+import com.swc.sampleapp.databinding.FragmentMainHome3Binding
 
 
 /**
 Created by sangwn.choi on2020-07-03
 
  **/
-class SplashActivity : BaseSplashActivity() {
+class SplashActivity : BaseSplashActivity<ActivitySplashBinding>() {
     override val myClass: Class<*>?
         get() = MainActivity::class.java
     override val mLayoutId: Int
         get() = R.layout.activity_splash
 
+    override val bindingInflater: (LayoutInflater) -> ActivitySplashBinding = {
+            inflater -> ActivitySplashBinding.inflate(inflater)
+    }
+    
     override fun setLayout() {
 
 

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/SplashActivity.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/activity/SplashActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.swc.common.ui.activity.BaseSplashActivity
+import com.swc.common.ui.custom.SToolbar
 import com.swc.common.util.LOG
 import com.swc.sampleapp.R
 import com.swc.sampleapp.databinding.ActivitySplashBinding
@@ -17,13 +18,13 @@ Created by sangwn.choi on2020-07-03
 class SplashActivity : BaseSplashActivity<ActivitySplashBinding>() {
     override val myClass: Class<*>?
         get() = MainActivity::class.java
-    override val mLayoutId: Int
-        get() = R.layout.activity_splash
+//    override val mLayoutId: Int
+//        get() = R.layout.activity_splash
 
     override val bindingInflater: (LayoutInflater) -> ActivitySplashBinding = {
             inflater -> ActivitySplashBinding.inflate(inflater)
     }
-    
+
     override fun setLayout() {
 
 
@@ -39,5 +40,9 @@ class SplashActivity : BaseSplashActivity<ActivitySplashBinding>() {
         })
         finish()
 
+    }
+
+    override fun getToolbar(): SToolbar? {
+        return null
     }
 }

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/adapter/DrawerEntryAdapter.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/adapter/DrawerEntryAdapter.kt
@@ -6,7 +6,9 @@ import android.view.ViewGroup
 import com.swc.common.ui.adapter.BaseAdapter
 import com.swc.common.ui.adapter.BaseViewHolder
 import com.swc.sampleapp.R
-import kotlinx.android.synthetic.main.item_list_drawer.view.*
+import com.swc.sampleapp.databinding.ItemListDrawerBinding
+
+//import kotlinx.android.synthetic.main.item_list_drawer.view.*
 
 class DrawerEntryAdapter @JvmOverloads constructor(headerCount: Int = 0, footerCount: Int = 0, clickListener: View.OnClickListener? = null) :
     BaseAdapter<DrawerItem>(headerCount, footerCount, clickListener) {
@@ -15,18 +17,20 @@ class DrawerEntryAdapter @JvmOverloads constructor(headerCount: Int = 0, footerC
         val inflater = LayoutInflater.from(parent.context)
         return DrawerEntryViewHolder(inflater.inflate(R.layout.item_list_drawer, parent, false)).apply {
             with(containerView) {
-                clDrawer?.setOnClickListener(clickListener)
+                binding.clDrawer.setOnClickListener(clickListener)
             }
         }
     }
 
     inner class DrawerEntryViewHolder(containerView: View) : BaseViewHolder(containerView) {
+        override val binding = ItemListDrawerBinding.bind(containerView)
+
         override fun bindVH(position: Int) {
             with(containerView) {
                 val item = getItem(position)
                 item?.run {
-                    tvRowTitle?.text = title
-                    ivRowIcon?.setImageResource(resId)
+                    binding.tvRowTitle.text = title
+                    binding.ivRowIcon.setImageResource(resId)
                 }
             }
         }

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
@@ -14,7 +14,7 @@ import com.swc.sampleapp.ui.activity.MainActivity
 import com.trello.rxlifecycle4.android.FragmentEvent
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.android.synthetic.main.fragment_main_home3.*
+//import kotlinx.android.synthetic.main.fragment_main_home3.*
 
 
 /**
@@ -22,8 +22,8 @@ Created by sangwn.choi on2020-07-08
 
  **/
 class MainHomeFragment : BaseFragment<FragmentMainHome3Binding>() {
-    override val layoutId: Int
-        get() = R.layout.fragment_main_home3
+//    override val layoutId: Int
+//        get() = R.layout.fragment_main_home3
 
     override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentMainHome3Binding = {
             inflater, container, attachToParent -> FragmentMainHome3Binding.inflate(inflater, container, attachToParent)
@@ -39,11 +39,11 @@ class MainHomeFragment : BaseFragment<FragmentMainHome3Binding>() {
         arguments?.run {
             LOG.e("bundle arg $this")
         } ?: run {
-            loadFresh()
+//            loadFresh()
         }
 
         context?.let {
-            rvMainMenu?.addItemDecoration(MiddleDividerItemDecoration(it, MiddleDividerItemDecoration.ALL))
+//            rvMainMenu?.addItemDecoration(MiddleDividerItemDecoration(it, MiddleDividerItemDecoration.ALL))
             binding.rvMainMenu.addItemDecoration(MiddleDividerItemDecoration(it, MiddleDividerItemDecoration.ALL))
         }
 
@@ -78,7 +78,10 @@ class MainHomeFragment : BaseFragment<FragmentMainHome3Binding>() {
     }
 
     override fun setToolbar() {
+        LOG.e("mainhomefragment setToolBar")
+
         getBaseActivity<ActivityMainBinding>()?.getToolbar()?.run {
+            LOG.e("mainhomefrag toolbar nonnull")
             setSToolbarTitle(getString(R.string.app_name))
         }
     }

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
@@ -1,11 +1,15 @@
 package com.swc.sampleapp.ui.fragment
 
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import com.swc.common.ui.fragment.BaseFragment
 import com.swc.common.util.*
 import com.swc.sampleapp.R
 import com.swc.sampleapp.UserApiClient
 import com.swc.sampleapp.UserApplication
+import com.swc.sampleapp.databinding.ActivityMainBinding
+import com.swc.sampleapp.databinding.FragmentMainHome3Binding
 import com.swc.sampleapp.ui.activity.MainActivity
 import com.trello.rxlifecycle4.android.FragmentEvent
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -17,12 +21,16 @@ import kotlinx.android.synthetic.main.fragment_main_home3.*
 Created by sangwn.choi on2020-07-08
 
  **/
-class MainHomeFragment : BaseFragment() {
+class MainHomeFragment : BaseFragment<FragmentMainHome3Binding>() {
     override val layoutId: Int
         get() = R.layout.fragment_main_home3
 
+    override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentMainHome3Binding = {
+            inflater, container, attachToParent -> FragmentMainHome3Binding.inflate(inflater, container, attachToParent)
+    }
+
     override fun setLayout() {
-        loadingView = (getBaseActivity() as? MainActivity)?.findViewById(R.id.lvMain)
+        loadingView = (getBaseActivity<ActivityMainBinding>() as? MainActivity)?.findViewById(R.id.lvMain)
 
         //TODO: 최근 공지사항, 감염병정보를 리스트에 그리기 위해 API 호출.
         //TODO: 여기서는 ALL 대신 게시 영역 별로 조회를 해야 한다. (공지사항, 감염병 정보)
@@ -36,7 +44,9 @@ class MainHomeFragment : BaseFragment() {
 
         context?.let {
             rvMainMenu?.addItemDecoration(MiddleDividerItemDecoration(it, MiddleDividerItemDecoration.ALL))
+            binding.rvMainMenu.addItemDecoration(MiddleDividerItemDecoration(it, MiddleDividerItemDecoration.ALL))
         }
+
 
     }
 
@@ -68,7 +78,7 @@ class MainHomeFragment : BaseFragment() {
     }
 
     override fun setToolbar() {
-        getBaseActivity()?.getToolbar()?.run {
+        getBaseActivity<ActivityMainBinding>()?.getToolbar()?.run {
             setSToolbarTitle(getString(R.string.app_name))
         }
     }

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
@@ -1,6 +1,7 @@
 package com.swc.sampleapp.ui.fragment
 
 import android.view.View
+import androidx.lifecycle.lifecycleScope
 import com.swc.common.ui.fragment.BaseFragment
 import com.swc.common.util.*
 import com.swc.sampleapp.R
@@ -11,6 +12,9 @@ import com.trello.rxlifecycle4.android.FragmentEvent
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_main_home3.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 /**
@@ -47,22 +51,35 @@ class MainHomeFragment : BaseFragment() {
         //TODO: load API call
 
         showLoading()
-        UserApiClient.getClient().getCk()
-            .compose(bindUntilEvent(FragmentEvent.DESTROY))
-            .observeOn(Schedulers.io())
-            .doOnNext {
-                LOG.e("result : ${it.result}")
+
+        lifecycleScope.launchWhenStarted {
+            try {
+                var res = UserApiClient.getClient().getCk()
+                LOG.e("result : ${res.result}")
+                LOG.e("getCk on success action")
+            } catch (exception: Exception) {
+                LOG.e("getCk on err action: $exception")
             }
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(ApiClient.UserSubscriber({
-                LOG.e("getCk on success action $it")
+            withContext(Dispatchers.Main) {
                 hideLoading()
-            }, {
-                LOG.e("getCk on err action: $it")
-                hideLoading()
-            }, {
-                LOG.e("getCk on complete action")
-            }))
+            }
+        }
+//        UserApiClient.getClient().getCk()
+//            .compose(bindUntilEvent(FragmentEvent.DESTROY))
+//            .observeOn(Schedulers.io())
+//            .doOnNext {
+//                LOG.e("result : ${it.result}")
+//            }
+//            .observeOn(AndroidSchedulers.mainThread())
+//            .subscribe(ApiClient.UserSubscriber({
+//                LOG.e("getCk on success action $it")
+//                hideLoading()
+//            }, {
+//                LOG.e("getCk on err action: $it")
+//                hideLoading()
+//            }, {
+//                LOG.e("getCk on complete action")
+//            }))
 
 
     }

--- a/sampleapp/src/main/res/layout/activity_main.xml
+++ b/sampleapp/src/main/res/layout/activity_main.xml
@@ -23,7 +23,7 @@
             android:layout_height="wrap_content">
 
             <com.swc.common.ui.custom.SToolbar
-                android:id="@+id/sToolbar"
+                android:id="@+id/toolbar_id"
                 app:contentInsetLeft="0dp"
                 app:contentInsetStart="0dp"
                 android:layout_width="match_parent"
@@ -31,10 +31,18 @@
                 android:background="@color/white">
             </com.swc.common.ui.custom.SToolbar>
 
+<!--            <include android:id="@+id/toolbar_id"-->
+<!--                app:contentInsetLeft="0dp"-->
+<!--                app:contentInsetStart="0dp"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="@dimen/common_toolbar_height"-->
+<!--                android:background="@color/white"-->
+<!--                layout="@layout/drawer_toolbar" />-->
+
             <View
                 android:id="@+id/vBorder"
                 android:layout_width="match_parent"
-                app:layout_constraintBottom_toBottomOf="@id/sToolbar"
+                app:layout_constraintBottom_toBottomOf="@id/toolbar_id"
                 android:layout_height="1dp"
                 android:background="@color/gray01"
                 />
@@ -120,6 +128,7 @@
                 tools:itemCount="6" />
 
             <include
+                android:id="@+id/navFooter"
                 layout="@layout/nav_footer"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />


### PR DESCRIPTION
- Kotlin synthetic 방식은 deprecate 예정이라, https://developer.android.com/topic/libraries/view-binding#fragments 공식 가이드 활용하여 migration 을 진행한다.
- Base Fragment, Activity 에 변경점을 적용하고, 각 child 뷰에서는 binding class 만 지정해주는 방식으로 구현함.