### PR TITLE
Migrate from RxJava to Kotlin coroutines.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
+apply plugin: 'kotlin-kapt'
+
 android {
     compileSdkVersion 29
 
@@ -127,6 +129,16 @@ dependencies {
     api 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
     api 'com.squareup.okhttp3:okhttp:3.11.0'
     api 'com.squareup.okhttp3:logging-interceptor:3.11.0'
+
+    //Kotlin Coroutines
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
+    api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1'
+
+    //Jetpack
+    api 'androidx.lifecycle:lifecycle-runtime:2.2.0-alpha01'
+    api 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-alpha01'
+    kapt 'androidx.lifecycle:lifecycle-compiler:2.2.0-alpha01'
+
     testImplementation 'junit:junit:4.12'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/sampleapp/src/main/java/com/swc/sampleapp/UserApiClient.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/UserApiClient.kt
@@ -21,8 +21,11 @@ Created by sangwn.choi on2020-07-13
 interface UserApiClient {
 
 
+//    @GET("ck")
+//    fun getCk(): Flowable<BResponse<SampleResp>>
+
     @GET("ck")
-    fun getCk(): Flowable<BResponse<SampleResp>>
+    suspend fun getCk(): BResponse<SampleResp>
 
     companion object {
         private var retrofit: Retrofit? = null
@@ -34,7 +37,7 @@ interface UserApiClient {
                     .addConverterFactory(GsonConverterFactory.create())
                     .baseUrl(BASE_URL)
                     .client(ApiClient.client)
-                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+//                    .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                     .build()
             }
             return retrofit!!.create(UserApiClient::class.java)

--- a/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
+++ b/sampleapp/src/main/java/com/swc/sampleapp/ui/fragment/MainHomeFragment.kt
@@ -1,6 +1,7 @@
 package com.swc.sampleapp.ui.fragment
 
 import android.view.View
+import androidx.lifecycle.lifecycleScope
 import com.swc.common.ui.fragment.BaseFragment
 import com.swc.common.util.*
 import com.swc.sampleapp.R
@@ -11,6 +12,9 @@ import com.trello.rxlifecycle4.android.FragmentEvent
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_main_home3.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 /**
@@ -47,22 +51,35 @@ class MainHomeFragment : BaseFragment() {
         //TODO: load API call
 
         showLoading()
-        UserApiClient.getClient().getCk()
-            .compose(bindUntilEvent(FragmentEvent.DESTROY))
-            .observeOn(Schedulers.io())
-            .doOnNext {
-                LOG.e("result : ${it.result}")
+
+        lifecycleScope.launchWhenStarted {
+            try {
+                var res = UserApiClient.getClient().getCk()
+                LOG.e("result : ${res.result}")
+                LOG.e("getCk on success action")
+            } catch (exception: Exception) {
+                LOG.e("getCk on err action: $exception")
             }
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(ApiClient.UserSubscriber({
-                LOG.e("getCk on success action $it")
+            withContext(Dispatchers.Main) {
                 hideLoading()
-            }, {
-                LOG.e("getCk on err action: $it")
-                hideLoading()
-            }, {
-                LOG.e("getCk on complete action")
-            }))
+            }
+        }
+//        UserApiClient.getClient().getCk()
+//            .compose(bindUntilEvent(FragmentEvent.DESTROY))
+//            .observeOn(Schedulers.io())
+//            .doOnNext {
+//                LOG.e("result : ${it.result}")
+//            }
+//            .observeOn(AndroidSchedulers.mainThread())
+//            .subscribe(ApiClient.UserSubscriber({
+//                LOG.e("getCk on success action $it")
+//                hideLoading()
+//            }, {
+//                LOG.e("getCk on err action: $it")
+//                hideLoading()
+//            }, {
+//                LOG.e("getCk on complete action")
+//            }))
 
 
     }


### PR DESCRIPTION
- Replace rxjava flowable api definitions with coroutine implementations